### PR TITLE
Issue #28 fix.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 PROJECT_NAME := esp32-cam-demo
+PROJECT_NAME := esp32-cam-demo
 
 include $(IDF_PATH)/make/project.mk
-


### PR DESCRIPTION
Add a Wno-error for unused-const-variable to CFLAGS.

The issue happened because unused constant warning treated as error. This commit fixes that.